### PR TITLE
Update `bytestring >= 0.11` constructors

### DIFF
--- a/src/Data/ByteString/Base32.hs
+++ b/src/Data/ByteString/Base32.hs
@@ -89,7 +89,7 @@ encodeBase32' = encodeBase32_ "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"#
 -- Left "Base32-encoded bytestring has invalid padding"
 --
 decodeBase32 :: ByteString -> Either Text ByteString
-decodeBase32 bs@(PS _ _ !l)
+decodeBase32 bs@(BS _ !l)
     | l == 0 = Right bs
     | r == 0 = unsafeDupablePerformIO $ decodeBase32_ stdDecodeTable bs
     | r == 2 = unsafeDupablePerformIO $ decodeBase32_ stdDecodeTable (BS.append bs "======")
@@ -140,7 +140,7 @@ encodeBase32Unpadded' = encodeBase32NoPad_ "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"#
 -- Left "Base32-encoded bytestring has invalid padding"
 --
 decodeBase32Unpadded :: ByteString -> Either Text ByteString
-decodeBase32Unpadded bs@(PS _ _ !l)
+decodeBase32Unpadded bs@(BS _ !l)
     | l == 0 = Right bs
     | r == 0 = validateLastNPads 1 bs $ decodeBase32_ stdDecodeTable bs
     | r == 2 = unsafeDupablePerformIO $ decodeBase32_ stdDecodeTable (BS.append bs "======")
@@ -165,7 +165,7 @@ decodeBase32Unpadded bs@(PS _ _ !l)
 -- Left "Base32-encoded bytestring requires padding"
 --
 decodeBase32Padded :: ByteString -> Either Text ByteString
-decodeBase32Padded bs@(PS _ _ !l)
+decodeBase32Padded bs@(BS _ !l)
     | l == 0 = Right bs
     | r == 1 = Left "Base32-encoded bytestring has invalid size"
     | r == 3 = Left "Base32-encoded bytestring has invalid size"

--- a/src/Data/ByteString/Base32/Hex.hs
+++ b/src/Data/ByteString/Base32/Hex.hs
@@ -89,7 +89,7 @@ encodeBase32' = encodeBase32_ "0123456789ABCDEFGHIJKLMNOPQRSTUV"#
 -- Left "Base32-encoded bytestring has invalid padding"
 --
 decodeBase32 :: ByteString -> Either Text ByteString
-decodeBase32 bs@(PS _ _ !l)
+decodeBase32 bs@(BS _ !l)
     | l == 0 = Right bs
     | r == 0 = unsafeDupablePerformIO $ decodeBase32_ hexDecodeTable bs
     | r == 2 = unsafeDupablePerformIO $ decodeBase32_ hexDecodeTable (BS.append bs "======")
@@ -140,7 +140,7 @@ encodeBase32Unpadded' = encodeBase32NoPad_ "0123456789ABCDEFGHIJKLMNOPQRSTUV"#
 -- Left "Base32-encoded bytestring has invalid padding"
 --
 decodeBase32Unpadded :: ByteString -> Either Text ByteString
-decodeBase32Unpadded bs@(PS _ _ !l)
+decodeBase32Unpadded bs@(BS _ !l)
     | l == 0 = Right bs
     | r == 0 = validateLastNPads 1 bs $ decodeBase32_ hexDecodeTable bs
     | r == 2 = unsafeDupablePerformIO $ decodeBase32_ hexDecodeTable (BS.append bs "======")
@@ -165,7 +165,7 @@ decodeBase32Unpadded bs@(PS _ _ !l)
 -- Left "Base32-encoded bytestring requires padding"
 --
 decodeBase32Padded :: ByteString -> Either Text ByteString
-decodeBase32Padded bs@(PS _ _ !l)
+decodeBase32Padded bs@(BS _ !l)
     | l == 0 = Right bs
     | r == 1 = Left "Base32-encoded bytestring has invalid size"
     | r == 3 = Left "Base32-encoded bytestring has invalid size"

--- a/src/Data/ByteString/Base32/Internal.hs
+++ b/src/Data/ByteString/Base32/Internal.hs
@@ -43,7 +43,7 @@ import System.IO.Unsafe
 -- | Validate a base32-encoded bytestring against some alphabet.
 --
 validateBase32 :: ByteString -> ByteString -> Bool
-validateBase32 !alphabet bs@(PS _ _ l)
+validateBase32 !alphabet bs@(BS _ l)
     | l == 0 = True
     | r == 0 = f bs
     | r == 2 = f (BS.append bs "======")
@@ -54,8 +54,8 @@ validateBase32 !alphabet bs@(PS _ _ l)
   where
     r = l `rem` 8
 
-    f (PS fp o l') = accursedUnutterablePerformIO $ withForeignPtr fp $ \p ->
-      go (plusPtr p o) (plusPtr p (l' + o))
+    f (BS fp l') = accursedUnutterablePerformIO $ withForeignPtr fp $ \p ->
+      go p (plusPtr p l')
 
     go !p !end
       | p == end = return True
@@ -105,13 +105,12 @@ validateLastNPads
     -> ByteString
     -> IO (Either Text ByteString)
     -> Either Text ByteString
-validateLastNPads !n (PS !fp !o !l) io
+validateLastNPads !n (BS !fp !l) io
     | not valid = Left "Base32-encoded bytestring has invalid padding"
     | otherwise = unsafeDupablePerformIO io
   where
-    !lo = l + o
     valid = accursedUnutterablePerformIO $ withForeignPtr fp $ \p -> do
-      let end = plusPtr p lo
+      let end = plusPtr p l
 
       let go :: Ptr Word8 -> IO Bool
           go !q
@@ -120,5 +119,5 @@ validateLastNPads !n (PS !fp !o !l) io
               a <- peek q
               if a == 0x3d then return False else go (plusPtr q 1)
 
-      go (plusPtr p (lo - n))
+      go (plusPtr p (l - n))
 {-# INLINE validateLastNPads #-}

--- a/src/Data/ByteString/Base32/Internal.hs
+++ b/src/Data/ByteString/Base32/Internal.hs
@@ -1,8 +1,5 @@
 {-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE CPP #-}
-{-# LANGUAGE MagicHash #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TypeApplications #-}
 -- |
 -- Module       : Data.ByteString.Base32.Internal
 -- Copyright 	: (c) 2020 Emily Pillmore

--- a/src/Data/ByteString/Base32/Internal/Head.hs
+++ b/src/Data/ByteString/Base32/Internal/Head.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE MagicHash #-}
+{-# LANGUAGE TypeApplications #-}
 module Data.ByteString.Base32.Internal.Head
 ( encodeBase32_
 , encodeBase32NoPad_

--- a/src/Data/ByteString/Base32/Internal/Head.hs
+++ b/src/Data/ByteString/Base32/Internal/Head.hs
@@ -71,7 +71,6 @@ decodeBase32_ (Ptr !dtable) (BS !sfp !slen) =
       dfp <- mallocPlainForeignPtrBytes dlen
       withForeignPtr dfp $ \dptr -> do
         let !end = plusPtr sptr slen
-            !sptr64 = castPtr sptr
-        decodeLoop dtable dfp dptr sptr64 end
+        decodeLoop dtable dfp dptr sptr end
   where
     !dlen = ceiling (fromIntegral @_ @Double slen / 1.6)

--- a/src/Data/ByteString/Base32/Internal/Head.hs
+++ b/src/Data/ByteString/Base32/Internal/Head.hs
@@ -30,13 +30,13 @@ import System.IO.Unsafe
 -- executes the inner encoding loop against that data.
 --
 encodeBase32_ :: Addr# -> ByteString -> ByteString
-encodeBase32_ !lut (PS !sfp !o !l) = unsafeDupablePerformIO $ do
+encodeBase32_ !lut (BS !sfp !l) = unsafeDupablePerformIO $ do
     dfp <- mallocPlainForeignPtrBytes dlen
     withForeignPtr dfp $ \dptr ->
       withForeignPtr sfp $ \sptr -> do
-        let !end = plusPtr sptr (l + o)
+        let !end = plusPtr sptr l
         innerLoop lut
-          (castPtr dptr) (plusPtr sptr o)
+          (castPtr dptr) sptr
           end (loopTail lut dfp dptr end)
   where
     !dlen = ceiling (fromIntegral @_ @Double l / 5) * 8
@@ -48,13 +48,13 @@ encodeBase32_ !lut (PS !sfp !o !l) = unsafeDupablePerformIO $ do
 -- executes the inner encoding loop against that data.
 --
 encodeBase32NoPad_ :: Addr# -> ByteString -> ByteString
-encodeBase32NoPad_ !lut (PS !sfp !o !l) = unsafeDupablePerformIO $ do
+encodeBase32NoPad_ !lut (BS !sfp !l) = unsafeDupablePerformIO $ do
     !dfp <- mallocPlainForeignPtrBytes dlen
     withForeignPtr dfp $ \dptr ->
       withForeignPtr sfp $ \sptr -> do
-        let !end = plusPtr sptr (l + o)
+        let !end = plusPtr sptr l
         innerLoop lut
-          (castPtr dptr) (plusPtr sptr o)
+          (castPtr dptr) sptr
           end (loopTailNoPad lut dfp dptr end)
   where
     !dlen = ceiling (fromIntegral @_ @Double l / 5) * 8
@@ -66,11 +66,12 @@ encodeBase32NoPad_ !lut (PS !sfp !o !l) = unsafeDupablePerformIO $ do
 -- and executes the inner decoding loop against that data.
 --
 decodeBase32_ :: Ptr Word8 -> ByteString -> IO (Either Text ByteString)
-decodeBase32_ (Ptr !dtable) (PS !sfp !soff !slen) =
+decodeBase32_ (Ptr !dtable) (BS !sfp !slen) =
     withForeignPtr sfp $ \sptr -> do
       dfp <- mallocPlainForeignPtrBytes dlen
       withForeignPtr dfp $ \dptr -> do
-        let !end = plusPtr sptr (soff + slen)
-        decodeLoop dtable dfp dptr (plusPtr sptr soff) end
+        let !end = plusPtr sptr slen
+            !sptr64 = castPtr sptr
+        decodeLoop dtable dfp dptr sptr64 end
   where
     !dlen = ceiling (fromIntegral @_ @Double slen / 1.6)

--- a/src/Data/ByteString/Base32/Internal/Loop.hs
+++ b/src/Data/ByteString/Base32/Internal/Loop.hs
@@ -149,18 +149,18 @@ decodeLoop !lut !dfp !dptr !sptr !end = go dptr sptr
 
         case (c,d,e,f,g,h) of
           (0x63,0x63,0x63,0x63,0x63,0x63) ->
-            return (Right (PS dfp 0 (1 + minusPtr dst dptr)))
+            return (Right (BS dfp (1 + minusPtr dst dptr)))
           (0x63,_,_,_,_,_) -> padErr (plusPtr src 3)
           (_,0x63,0x63,0x63,0x63,0x63) -> padErr (plusPtr src 3)
           (_,0x63,_,_,_,_) -> padErr (plusPtr src 4)
           (_,_,0x63,0x63,0x63,0x63) -> do
             poke @Word8 (plusPtr dst 2) o3
-            return (Right (PS dfp 0 (2 + minusPtr dst dptr)))
+            return (Right (BS dfp (2 + minusPtr dst dptr)))
           (_,_,0x63,_,_,_) -> padErr (plusPtr src 5)
           (_,_,_,0x63,0x63,0x63) -> do
             poke @Word8 (plusPtr dst 2) o3
             poke @Word8 (plusPtr dst 3) o4
-            return (Right (PS dfp 0 (3 + minusPtr dst dptr)))
+            return (Right (BS dfp (3 + minusPtr dst dptr)))
           (_,_,_,0x63,_,_) -> padErr (plusPtr src 6)
           (_,_,_,_,0x63,0x63) -> padErr (plusPtr src 6)
           (_,_,_,_,0x63,_) -> padErr (plusPtr src 7)
@@ -168,12 +168,12 @@ decodeLoop !lut !dfp !dptr !sptr !end = go dptr sptr
             poke @Word8 (plusPtr dst 2) o3
             poke @Word8 (plusPtr dst 3) o4
             poke @Word8 (plusPtr dst 4) o5
-            return (Right (PS dfp 0 (4 + minusPtr dst dptr)))
+            return (Right (BS dfp (4 + minusPtr dst dptr)))
           (_,_,_,_,_,_) -> do
             poke @Word8 (plusPtr dst 2) o3
             poke @Word8 (plusPtr dst 3) o4
             poke @Word8 (plusPtr dst 4) o5
-            return (Right (PS dfp 0 (5 + minusPtr dst dptr)))
+            return (Right (BS dfp (5 + minusPtr dst dptr)))
 
     decodeChunk !dst !src !a !b !c !d !e !f !g !h
       | a == 0x63 = padErr src

--- a/src/Data/ByteString/Base32/Internal/Loop.hs
+++ b/src/Data/ByteString/Base32/Internal/Loop.hs
@@ -1,7 +1,5 @@
 {-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE MagicHash #-}
-{-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE TypeApplications #-}
 module Data.ByteString.Base32.Internal.Loop
 ( innerLoop

--- a/src/Data/ByteString/Base32/Internal/Loop.hs
+++ b/src/Data/ByteString/Base32/Internal/Loop.hs
@@ -70,43 +70,41 @@ decodeLoop
     :: Addr#
     -> ForeignPtr Word8
     -> Ptr Word8
-    -> Ptr Word64
+    -> Ptr Word8
     -> Ptr Word8
     -> IO (Either Text ByteString)
 decodeLoop !lut !dfp !dptr !sptr !end = go dptr sptr
   where
     lix a = w64 (aix (fromIntegral a) lut)
 
-    err :: Ptr Word64 -> IO (Either Text ByteString)
+    err :: Ptr Word8 -> IO (Either Text ByteString)
     err p = return . Left . T.pack
       $ "invalid character at offset: "
       ++ show (p `minusPtr` sptr)
 
-    padErr :: Ptr Word64 -> IO (Either Text ByteString)
+    padErr :: Ptr Word8 -> IO (Either Text ByteString)
     padErr p =  return . Left . T.pack
       $ "invalid padding at offset: "
       ++ show (p `minusPtr` sptr)
 
     look :: Ptr Word8 -> IO Word64
-    look !p = lix . w64 <$> peek @Word8 p
+    look !p = lix <$> peek @Word8 p
 
     go !dst !src
       | plusPtr src 8 >= end = do
 
-        let src' = castPtr src
-
-        a <- look src'
-        b <- look (plusPtr src' 1)
-        c <- look (plusPtr src' 2)
-        d <- look (plusPtr src' 3)
-        e <- look (plusPtr src' 4)
-        f <- look (plusPtr src' 5)
-        g <- look (plusPtr src' 6)
-        h <- look (plusPtr src' 7)
+        a <- look src
+        b <- look (plusPtr src 1)
+        c <- look (plusPtr src 2)
+        d <- look (plusPtr src 3)
+        e <- look (plusPtr src 4)
+        f <- look (plusPtr src 5)
+        g <- look (plusPtr src 6)
+        h <- look (plusPtr src 7)
         finalChunk dst src a b c d e f g h
 
       | otherwise = do
-        !t <- peekWord64BE src
+        !t <- peekWord64BE (castPtr src)
 
         let a = lix (unsafeShiftR t 56)
             b = lix (unsafeShiftR t 48)

--- a/src/Data/ByteString/Base32/Internal/Tables.hs
+++ b/src/Data/ByteString/Base32/Internal/Tables.hs
@@ -5,9 +5,9 @@ module Data.ByteString.Base32.Internal.Tables
 ) where
 
 
-import Data.ByteString.Base32.Internal.Utils
+import Data.ByteString.Base32.Internal.Utils (writeNPlainPtrBytes)
 
-import GHC.Word
+import GHC.Word (Word8)
 import GHC.Ptr (Ptr)
 
 

--- a/src/Data/ByteString/Base32/Internal/Tables.hs
+++ b/src/Data/ByteString/Base32/Internal/Tables.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE MagicHash #-}
 {-# LANGUAGE TypeApplications #-}
 module Data.ByteString.Base32.Internal.Tables
 ( stdDecodeTable

--- a/src/Data/ByteString/Base32/Internal/Tail.hs
+++ b/src/Data/ByteString/Base32/Internal/Tail.hs
@@ -33,7 +33,7 @@ loopTail
     -> Ptr Word8
     -> IO ByteString
 loopTail !lut !dfp !dptr !end !dst !src
-    | src == end = return (PS dfp 0 (minusPtr dst dptr))
+    | src == end = return (BS dfp (minusPtr dst dptr))
     | plusPtr src 1 == end = do -- 2 6
       !a <- peek src
 
@@ -44,7 +44,7 @@ loopTail !lut !dfp !dptr !end !dst !src
       poke (plusPtr dst 1) u
       padN (plusPtr dst 2) 6
 
-      return (PS dfp 0 (8 + minusPtr dst dptr))
+      return (BS dfp (8 + minusPtr dst dptr))
     | plusPtr src 2 == end = do -- 4 4
       !a <- peek src
       !b <- peek (plusPtr src 1)
@@ -60,7 +60,7 @@ loopTail !lut !dfp !dptr !end !dst !src
       poke (plusPtr dst 3) w
       padN (plusPtr dst 4) 4
 
-      return (PS dfp 0 (8 + minusPtr dst dptr))
+      return (BS dfp (8 + minusPtr dst dptr))
     | plusPtr src 3 == end = do -- 5 3
       !a <- peek src
       !b <- peek (plusPtr src 1)
@@ -78,7 +78,7 @@ loopTail !lut !dfp !dptr !end !dst !src
       poke (plusPtr dst 3) w
       poke (plusPtr dst 4) x
       padN (plusPtr dst 5) 3
-      return (PS dfp 0 (8 + minusPtr dst dptr))
+      return (BS dfp (8 + minusPtr dst dptr))
 
     | otherwise = do -- 7 1
       !a <- peek src
@@ -102,7 +102,7 @@ loopTail !lut !dfp !dptr !end !dst !src
       poke (plusPtr dst 5) y
       poke (plusPtr dst 6) z
       padN (plusPtr dst 7) 1
-      return (PS dfp 0 (8 + minusPtr dst dptr))
+      return (BS dfp (8 + minusPtr dst dptr))
   where
     look !n = aix n lut
 
@@ -122,7 +122,7 @@ loopTailNoPad
     -> Ptr Word8
     -> IO ByteString
 loopTailNoPad !lut !dfp !dptr !end !dst !src
-  | src == end = return (PS dfp 0 (minusPtr dst dptr))
+  | src == end = return (BS dfp (minusPtr dst dptr))
   | plusPtr src 1 == end = do -- 2 6
       !a <- peek src
 
@@ -132,7 +132,7 @@ loopTailNoPad !lut !dfp !dptr !end !dst !src
       poke dst t
       poke (plusPtr dst 1) u
 
-      return (PS dfp 0 (2 + minusPtr dst dptr))
+      return (BS dfp (2 + minusPtr dst dptr))
 
     | plusPtr src 2 == end = do -- 4 4
       !a <- peek src
@@ -148,7 +148,7 @@ loopTailNoPad !lut !dfp !dptr !end !dst !src
       poke (plusPtr dst 2) v
       poke (plusPtr dst 3) w
 
-      return (PS dfp 0 (4 + minusPtr dst dptr))
+      return (BS dfp (4 + minusPtr dst dptr))
 
     | plusPtr src 3 == end = do -- 5 3
       !a <- peek src
@@ -166,7 +166,7 @@ loopTailNoPad !lut !dfp !dptr !end !dst !src
       poke (plusPtr dst 2) v
       poke (plusPtr dst 3) w
       poke (plusPtr dst 4) x
-      return (PS dfp 0 (5 + minusPtr dst dptr))
+      return (BS dfp (5 + minusPtr dst dptr))
 
     | otherwise = do -- 7 1
       !a <- peek src
@@ -189,7 +189,7 @@ loopTailNoPad !lut !dfp !dptr !end !dst !src
       poke (plusPtr dst 4) x
       poke (plusPtr dst 5) y
       poke (plusPtr dst 6) z
-      return (PS dfp 0 (7 + minusPtr dst dptr))
+      return (BS dfp (7 + minusPtr dst dptr))
   where
     look !i = aix i lut
 {-# INLINE loopTailNoPad #-}

--- a/src/Data/ByteString/Base32/Internal/Tail.hs
+++ b/src/Data/ByteString/Base32/Internal/Tail.hs
@@ -1,9 +1,5 @@
 {-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MagicHash #-}
-{-# LANGUAGE MultiWayIf #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TypeApplications #-}
 module Data.ByteString.Base32.Internal.Tail
 ( loopTail
 , loopTailNoPad

--- a/src/Data/ByteString/Base32/Internal/Tail.hs
+++ b/src/Data/ByteString/Base32/Internal/Tail.hs
@@ -46,7 +46,7 @@ loopTail !lut !dfp !dptr !end !dst !src
       !b <- peek (plusPtr src 1)
 
       let !t = look (unsafeShiftR (a .&. 0xf8) 3)
-          !u = look ((unsafeShiftL (a .&. 0x07) 2) .|. (unsafeShiftR (b .&. 0xc0) 6))
+          !u = look (unsafeShiftL (a .&. 0x07) 2 .|. unsafeShiftR (b .&. 0xc0) 6)
           !v = look (unsafeShiftR (b .&. 0x3e) 1)
           !w = look (unsafeShiftL (b .&. 0x01) 4)
 
@@ -63,9 +63,9 @@ loopTail !lut !dfp !dptr !end !dst !src
       !c <- peek (plusPtr src 2)
 
       let !t = look (unsafeShiftR (a .&. 0xf8) 3)
-          !u = look ((unsafeShiftL (a .&. 0x07) 2) .|. (unsafeShiftR (b .&. 0xc0) 6))
+          !u = look (unsafeShiftL (a .&. 0x07) 2 .|. unsafeShiftR (b .&. 0xc0) 6)
           !v = look (unsafeShiftR (b .&. 0x3e) 1)
-          !w = look ((unsafeShiftL (b .&. 0x01) 4) .|. (unsafeShiftR (c .&. 0xf0) 4))
+          !w = look (unsafeShiftL (b .&. 0x01) 4 .|. unsafeShiftR (c .&. 0xf0) 4)
           !x = look (unsafeShiftL (c .&. 0x0f) 1)
 
       poke dst t
@@ -83,10 +83,10 @@ loopTail !lut !dfp !dptr !end !dst !src
       !d <- peek (plusPtr src 3)
 
       let !t = look (unsafeShiftR (a .&. 0xf8) 3)
-          !u = look ((unsafeShiftL (a .&. 0x07) 2) .|. (unsafeShiftR (b .&. 0xc0) 6))
+          !u = look (unsafeShiftL (a .&. 0x07) 2 .|. unsafeShiftR (b .&. 0xc0) 6)
           !v = look (unsafeShiftR (b .&. 0x3e) 1)
-          !w = look ((unsafeShiftL (b .&. 0x01) 4) .|. (unsafeShiftR (c .&. 0xf0) 4))
-          !x = look ((unsafeShiftL (c .&. 0x0f) 1) .|. (unsafeShiftR (d .&. 0x80) 7))
+          !w = look (unsafeShiftL (b .&. 0x01) 4 .|. unsafeShiftR (c .&. 0xf0) 4)
+          !x = look (unsafeShiftL (c .&. 0x0f) 1 .|. unsafeShiftR (d .&. 0x80) 7)
           !y = look (unsafeShiftR (d .&. 0x7c) 2)
           !z = look (unsafeShiftL (d .&. 0x03) 3)
 
@@ -135,7 +135,7 @@ loopTailNoPad !lut !dfp !dptr !end !dst !src
       !b <- peek (plusPtr src 1)
 
       let !t = look (unsafeShiftR (a .&. 0xf8) 3)
-          !u = look ((unsafeShiftL (a .&. 0x07) 2) .|. (unsafeShiftR (b .&. 0xc0) 6))
+          !u = look (unsafeShiftL (a .&. 0x07) 2 .|. unsafeShiftR (b .&. 0xc0) 6)
           !v = look (unsafeShiftR (b .&. 0x3e) 1)
           !w = look (unsafeShiftL (b .&. 0x01) 4)
 
@@ -152,9 +152,9 @@ loopTailNoPad !lut !dfp !dptr !end !dst !src
       !c <- peek (plusPtr src 2)
 
       let !t = look (unsafeShiftR (a .&. 0xf8) 3)
-          !u = look ((unsafeShiftL (a .&. 0x07) 2) .|. (unsafeShiftR (b .&. 0xc0) 6))
+          !u = look (unsafeShiftL (a .&. 0x07) 2 .|. unsafeShiftR (b .&. 0xc0) 6)
           !v = look (unsafeShiftR (b .&. 0x3e) 1)
-          !w = look ((unsafeShiftL (b .&. 0x01) 4) .|. (unsafeShiftR (c .&. 0xf0) 4))
+          !w = look (unsafeShiftL (b .&. 0x01) 4 .|. unsafeShiftR (c .&. 0xf0) 4)
           !x = look (unsafeShiftL (c .&. 0x0f) 1)
 
       poke dst t
@@ -171,10 +171,10 @@ loopTailNoPad !lut !dfp !dptr !end !dst !src
       !d <- peek (plusPtr src 3)
 
       let !t = look (unsafeShiftR (a .&. 0xf8) 3)
-          !u = look ((unsafeShiftL (a .&. 0x07) 2) .|. (unsafeShiftR (b .&. 0xc0) 6))
+          !u = look (unsafeShiftL (a .&. 0x07) 2 .|. unsafeShiftR (b .&. 0xc0) 6)
           !v = look (unsafeShiftR (b .&. 0x3e) 1)
-          !w = look ((unsafeShiftL (b .&. 0x01) 4) .|. (unsafeShiftR (c .&. 0xf0) 4))
-          !x = look ((unsafeShiftL (c .&. 0x0f) 1) .|. (unsafeShiftR (d .&. 0x80) 7))
+          !w = look (unsafeShiftL (b .&. 0x01) 4 .|. unsafeShiftR (c .&. 0xf0) 4)
+          !x = look (unsafeShiftL (c .&. 0x0f) 1 .|. unsafeShiftR (d .&. 0x80) 7)
           !y = look (unsafeShiftR (d .&. 0x7c) 2)
           !z = look (unsafeShiftL (d .&. 0x03) 3)
 

--- a/src/Data/ByteString/Lazy/Base32.hs
+++ b/src/Data/ByteString/Lazy/Base32.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE Trustworthy #-}
 -- |

--- a/src/Data/ByteString/Lazy/Base32/Hex.hs
+++ b/src/Data/ByteString/Lazy/Base32/Hex.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE Trustworthy #-}
 -- |


### PR DESCRIPTION
Same as in `base16`, since this package accepts `bytestring >= 0.11`, the `PS` pattern can be discarded for the actual `BS` data constructor, making some `plusPtr`s redundant.

The only part that I thought was weird was `decodeLoop` expecting a `Ptr Word64`, since the `ForeignPtr` from the ByteString is a `ForeignPtr Word8`, so is it necessary to cast it to a `Ptr Word64`? And can this be moved to the `decodeLoop`, since it's getting cast back to a `Ptr Word8` there anyway?